### PR TITLE
Ensures static assets are copied during dev

### DIFF
--- a/react_assets/package.json
+++ b/react_assets/package.json
@@ -21,7 +21,8 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "webpack": "^2.3.3",
-    "webpack-dev-server": "^2.4.2"
+    "webpack-dev-server": "^2.4.2",
+    "write-file-webpack-plugin": "^4.0.2"
   },
   "dependencies": {
     "react": "^15.5.3",

--- a/react_assets/webpack.config.js
+++ b/react_assets/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const publicPath = 'http://localhost:4002/'
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const WriteFilePlugin = require('write-file-webpack-plugin')
 
 const env = process.env.MIX_ENV || 'dev'
 const prod = env === 'prod'
@@ -15,13 +16,17 @@ const DEV_ENTRIES = [
 ]
 
 var plugins = [
-  new CopyWebpackPlugin([{ from: path.join(__dirname,'static') }]),
+  new CopyWebpackPlugin([{
+    from: path.join(__dirname, 'static'),
+    to: path.join(__dirname, '..', 'priv', 'static'),
+  }]),
   new webpack.optimize.OccurrenceOrderPlugin(),
   new webpack.NoEmitOnErrorsPlugin(),
   new webpack.DefinePlugin({
     __PROD: prod,
     __DEV: env === 'dev',
   }),
+  new WriteFilePlugin(),
 ]
 
 if (!prod) plugins.push(new webpack.HotModuleReplacementPlugin())


### PR DESCRIPTION
Static assets (e.g. favicon.ico, robots.txt, images, fonts etc.) weren't being served by Phoenix during development because `webpack-dev-server` doesn't build or copy those files to `priv/static`.